### PR TITLE
patch: write pth to temp dir.

### DIFF
--- a/lib/train/process_ckpt.py
+++ b/lib/train/process_ckpt.py
@@ -8,7 +8,7 @@ from i18n import I18nAuto
 i18n = I18nAuto()
 
 
-def savee(ckpt, sr, if_f0, name, epoch, version, hps):
+def savee(model_dir, ckpt, sr, if_f0, name, epoch, version, hps):
     try:
         opt = OrderedDict()
         opt["weight"] = {}
@@ -40,8 +40,7 @@ def savee(ckpt, sr, if_f0, name, epoch, version, hps):
         opt["sr"] = sr
         opt["f0"] = if_f0
         opt["version"] = version
-        name = name.split('/')[-1]
-        torch.save(opt, "weights/%s.pth" % name)
+        torch.save(opt, '%s/%s.pth' % (model_dir, name))
         return "Success."
     except:
         return traceback.format_exc()

--- a/lib/train/utils.py
+++ b/lib/train/utils.py
@@ -355,7 +355,7 @@ def get_hparams(init=True):
     )
 
     args = parser.parse_args()
-    name = args.experiment_dir
+    name = args.experiment_dir.split('/')[-1]
     experiment_dir = os.path.join("./logs", args.experiment_dir)
 
     if not os.path.exists(experiment_dir):

--- a/train_nsf_sim_cache_sid_load_pretrain.py
+++ b/train_nsf_sim_cache_sid_load_pretrain.py
@@ -555,6 +555,7 @@ def train_and_evaluate(
                     hps.name,
                     epoch,
                     savee(
+                        hps.model_dir,
                         ckpt,
                         hps.sample_rate,
                         hps.if_f0,
@@ -579,7 +580,7 @@ def train_and_evaluate(
             "saving final ckpt:%s"
             % (
                 savee(
-                    ckpt, hps.sample_rate, hps.if_f0, hps.name, epoch, hps.version, hps
+                    hps.model_dir, ckpt, hps.sample_rate, hps.if_f0, hps.name, epoch, hps.version, hps
                 )
             )
         )


### PR DESCRIPTION
This pr is injecting the model dir path in the temporary directory for saving the pth file.
It is necessary because we want to write files only to temporary directories so we dont bloat the endpoint.