### PR TITLE
patch: add exp_dir to pth save.

### DIFF
--- a/lib/train/process_ckpt.py
+++ b/lib/train/process_ckpt.py
@@ -8,7 +8,7 @@ from i18n import I18nAuto
 i18n = I18nAuto()
 
 
-def savee(model_dir, ckpt, sr, if_f0, name, epoch, version, hps):
+def savee(export_dir, ckpt, sr, if_f0, name, epoch, version, hps):
     try:
         opt = OrderedDict()
         opt["weight"] = {}
@@ -40,7 +40,7 @@ def savee(model_dir, ckpt, sr, if_f0, name, epoch, version, hps):
         opt["sr"] = sr
         opt["f0"] = if_f0
         opt["version"] = version
-        torch.save(opt, '%s/%s.pth' % (model_dir, name))
+        torch.save(opt, '%s/%s.pth' % (export_dir, name))
         return "Success."
     except:
         return traceback.format_exc()

--- a/lib/train/utils.py
+++ b/lib/train/utils.py
@@ -320,6 +320,9 @@ def get_hparams(init=True):
         "-e", "--experiment_dir", type=str, required=True, help="experiment dir"
     )  # -m
     parser.add_argument(
+        "-exp", "--export_dir", type=str, required=True, help="export dir"
+    )
+    parser.add_argument(
         "-sr", "--sample_rate", type=str, required=True, help="sample rate, 32k/40k/48k"
     )
     parser.add_argument(
@@ -379,6 +382,7 @@ def get_hparams(init=True):
     hparams = HParams(**config)
     hparams.model_dir = hparams.experiment_dir = experiment_dir
     hparams.save_every_epoch = args.save_every_epoch
+    hparams.export_dir = args.export_dir
     hparams.name = name
     hparams.total_epoch = args.total_epoch
     hparams.pretrainG = args.pretrainG

--- a/train_nsf_sim_cache_sid_load_pretrain.py
+++ b/train_nsf_sim_cache_sid_load_pretrain.py
@@ -555,7 +555,7 @@ def train_and_evaluate(
                     hps.name,
                     epoch,
                     savee(
-                        hps.model_dir,
+                        hps.export_dir,
                         ckpt,
                         hps.sample_rate,
                         hps.if_f0,
@@ -580,7 +580,7 @@ def train_and_evaluate(
             "saving final ckpt:%s"
             % (
                 savee(
-                    hps.model_dir, ckpt, hps.sample_rate, hps.if_f0, hps.name, epoch, hps.version, hps
+                    hps.export_dir, ckpt, hps.sample_rate, hps.if_f0, hps.name, epoch, hps.version, hps
                 )
             )
         )


### PR DESCRIPTION
This change enables the training module to inject the export path and avoid redundant model moves.